### PR TITLE
feat: Support self hosted instances

### DIFF
--- a/assets/js/embed.js
+++ b/assets/js/embed.js
@@ -27,5 +27,10 @@
 			}
 			p(cal, ar);
 		};
-})(window, "https://cal.com/embed.js", "init");
-Cal("init");
+})(window, customCalUrl.length == 0 ? "https://cal.com/embed.js" : customCalUrl + "/embed/embed.js", "init");
+if(customCalUrl.length == 0) {
+	Cal("init");
+}
+else {
+	Cal("init", {origin:customCalUrl})
+}

--- a/inc/class.embed.php
+++ b/inc/class.embed.php
@@ -33,7 +33,7 @@ class Embed
             switch ($atts['type']) {
                 case 2:
                     $output = '<span id="calcom-embed-link" data-cal-link="' . esc_attr($atts['url']) . '">' . esc_attr($atts['text']) . '</span>';
-                    $output .= '<script>const customCalUrl = "' . $atts['customCalInstance'] . '";</script>';
+                    $output .= '<script>var customCalUrl = "' . $atts['customCalInstance'] . '";</script>';
                     break;
                 default:
                     $output = '<div id="calcom-embed"></div>';
@@ -56,7 +56,7 @@ class Embed
     public function get_inline_embed_script($url, $custom_cal_url): string
     {
         $script = '<script>
-            const customCalUrl = "' . $custom_cal_url . '";
+            var customCalUrl = "' . $custom_cal_url . '";
             addEventListener("DOMContentLoaded", (event) => {
                 const selector = document.getElementById("calcom-embed");
                 Cal("inline", {

--- a/inc/class.embed.php
+++ b/inc/class.embed.php
@@ -103,9 +103,10 @@ class Embed
                 if (str_contains($atts['url'], 'https://cal.com/')) {
                     $url = str_replace('https://cal.com/', '/', $url);
                 }
-                elseif (str_contains($atts['url'], 'https://')) {
-                    // Start searching at position 8 to start after 'https://'
-                    $firstSlashPosition = strpos($url, '/', 8);
+                // 'https://' or 'http://' protocol indicate self-hosted instance
+                elseif (str_contains($atts['url'], 'https://') || str_contains($atts['url'], 'http://')) {
+                    // Start searching after 'http(s)://'
+                    $firstSlashPosition = strpos($url, '/', strlen(str_contains($atts['url'], 'https://') ? "https://" : "http://"));
                     $embed_custom_cal_url = substr($url, 0, $firstSlashPosition);
                     $url = substr($url, $firstSlashPosition);
                 }


### PR DESCRIPTION
Adds support for self-hosted instances. Fix https://github.com/calcom/wp-plugin/issues/2 . Supports `https` and `http` instances.

Shortcode can be used like this:

Inline Embed:
```
[cal url=http(s)://custom-cal-com-domain.tld/username/meetingid]
```
To make inline embed work I also used the code from @mario-neuhold in PR https://github.com/calcom/wp-plugin/pull/4 . Thanks for the fix.

Popup:
```
[cal url=http(s)://custom-cal-com-domain.tld/username/meetingid type=2 text="Let's Talk!"]
```