### PR TITLE
feat: Add support for floating popup embed

### DIFF
--- a/inc/class.embed.php
+++ b/inc/class.embed.php
@@ -35,7 +35,7 @@ class Embed
                     $output = '<span id="calcom-embed-link" data-cal-link="' . esc_attr($atts['url']) . '">' . esc_attr($atts['text']) . '</span>';
                     break;
                 case 3:
-                    $output = $this->get_floating_popup_embed_script($atts['url'], $atts['customCalInstance']);
+                    $output = $this->get_floating_popup_embed_script($atts['url'], $atts['text']);
                     break;
                 default:
                     $output = '<div id="calcom-embed"></div>';
@@ -58,9 +58,11 @@ class Embed
     {
         $script = '<script>
             const selector = document.getElementById("calcom-embed");
-            Cal("inline", {
-                elementOrSelector: selector,
-                calLink: "' . $url . '"
+            addEventListener("DOMContentLoaded", (event) => {
+                Cal("inline", {
+                    elementOrSelector: selector,
+                    calLink: "' . $url . '"
+                });
             });
         </script>';
 
@@ -71,13 +73,15 @@ class Embed
      * Adds floating-popup embed JS
      * 
      * @param $url Booking link
+     * @param $text Button text
      * @return string
      */
-    public function get_floating_popup_embed_script($url): string
+    public function get_floating_popup_embed_script($url, $text): string
     {
+        $button_text = strlen($text) > 0 ? '"buttonText":"' . $text . '"' : '';
         $script = '<script>
             addEventListener("DOMContentLoaded", (event) => {
-                Cal("floatingButton", {"calLink":"' . $url . '"});
+                Cal("floatingButton", {"calLink":"' . $url . '"' . (strlen($button_text) == 0 ? "" : "," . $button_text) . '});
             });
         </script>';
 

--- a/inc/class.embed.php
+++ b/inc/class.embed.php
@@ -34,6 +34,9 @@ class Embed
                 case 2:
                     $output = '<span id="calcom-embed-link" data-cal-link="' . esc_attr($atts['url']) . '">' . esc_attr($atts['text']) . '</span>';
                     break;
+                case 3:
+                    $output = $this->get_floating_popup_embed_script($atts['url'], $atts['customCalInstance']);
+                    break;
                 default:
                     $output = '<div id="calcom-embed"></div>';
                     $output .= $this->get_inline_embed_script($atts['url']);
@@ -58,6 +61,23 @@ class Embed
             Cal("inline", {
                 elementOrSelector: selector,
                 calLink: "' . $url . '"
+            });
+        </script>';
+
+        return $script;
+    }
+
+    /**
+     * Adds floating-popup embed JS
+     * 
+     * @param $url Booking link
+     * @return string
+     */
+    public function get_floating_popup_embed_script($url): string
+    {
+        $script = '<script>
+            addEventListener("DOMContentLoaded", (event) => {
+                Cal("floatingButton", {"calLink":"' . $url . '"});
             });
         </script>';
 


### PR DESCRIPTION
Adds shortcode support for [floating popup embed](https://cal.com/docs/core-features/embed/adding-embed-to-your-webpage#floating-button-pop-up).

Shortcode for floating-popup can be used like this:
```
[cal url=/username/meetingid type=3 text="Let's Talk!"]
```

Attribute `type=3` is mandatory and attribute `text` is optional. If text attribute is not specified a default text will be used.