### PR TITLE
Make floating popup work with self-hosted instance

### DIFF
--- a/inc/class.embed.php
+++ b/inc/class.embed.php
@@ -36,7 +36,7 @@ class Embed
                     $output .= '<script>var customCalUrl = "' . $atts['customCalInstance'] . '";</script>';
                     break;
                 case 3:
-                    $output = $this->get_floating_popup_embed_script($atts['url'], $atts['text']);
+                    $output = $this->get_floating_popup_embed_script($atts['url'], $atts['text'], $atts['customCalInstance']);
                     break;
                 default:
                     $output = '<div id="calcom-embed"></div>';
@@ -77,14 +77,22 @@ class Embed
      * 
      * @param $url Booking link
      * @param $text Button text
+     * @param $custom_cal_url Custom cal.com URL (if self-hosted instance is used)
      * @return string
      */
-    public function get_floating_popup_embed_script($url, $text): string
+    public function get_floating_popup_embed_script($url, $text, $custom_cal_url): string
     {
         $button_text = strlen($text) > 0 ? '"buttonText":"' . $text . '"' : '';
         $script = '<script>
+            var customCalUrl = "' . $custom_cal_url . '";
             addEventListener("DOMContentLoaded", (event) => {
                 Cal("floatingButton", {"calLink":"' . $url . '"' . (strlen($button_text) == 0 ? "" : "," . $button_text) . '});
+                if(customCalUrl.length == 0) {
+                    Cal("floatingButton", {"calLink":"' . $url . '"});
+                }
+                else {
+                    Cal("floatingButton", {"calLink":"' . $url . '","calOrigin":customCalUrl});
+                }
             });
         </script>';
 


### PR DESCRIPTION
The merging in https://github.com/calcom/wp-plugin/pull/5 wasn't quite complete as no support for self-hosted instances for option 3: floating popup embed was added. This PR completes the merge and makes the repository state consistent again. Strongly suggesting to merge this before publishing a new plugin version @PeerRich .