### PR TITLE
Fix self-hosted inline embed

### DIFF
--- a/inc/class.embed.php
+++ b/inc/class.embed.php
@@ -59,8 +59,8 @@ class Embed
     public function get_inline_embed_script($url, $custom_cal_url): string
     {
         $script = '<script>
+            var customCalUrl = "' . $custom_cal_url . '";
             addEventListener("DOMContentLoaded", (event) => {
-                var customCalUrl = "' . $custom_cal_url . '";
                 const selector = document.getElementById("calcom-embed");
                 Cal("inline", {
                     elementOrSelector: selector,


### PR DESCRIPTION
I had the problem that the inline embed of a self-hosted Cal.com instance wasn't rendered. I fixed it by loading `$custom_cal_url` outside the event listener.

It might fix https://github.com/calcom/wp-plugin/issues/12 for self-hosted instances. Although I'm not sure if in the issue only self-hosted instances were referenced.